### PR TITLE
将当前用户消息向右对齐，将其他消息向左对齐

### DIFF
--- a/chat.php
+++ b/chat.php
@@ -26,6 +26,7 @@ if (!isset($_SESSION['user'])) {
     <input type="text" id="message" autocomplete="off" placeholder="输入消息..." required>
     <button type="submit">发送</button>
 </form>
+<script>const currentUser = '<?php echo htmlspecialchars($_SESSION['user']); ?>';</script>
 <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -25,7 +25,11 @@ function fetchMessages() {
 }
 function addMessage(m) {
     const div = document.createElement('div');
-    div.className = 'message';
+    if (m.user === currentUser) {
+        div.className = 'message current-user-message';
+    } else {
+        div.className = 'message';
+    }
     div.innerHTML = `<strong>${m.user}</strong>: <span class="text">${m.text}</span>` +
         ` <span class="read">已读 ${m.read_by.length}</span>` +
         ` <div class="meta" style="display:none">${new Date(m.timestamp*1000).toLocaleString()}<br>${m.read_by.join(', ')}</div>`;


### PR DESCRIPTION
将当前用户消息向右对齐，将其他消息向左对齐

修改了聊天界面，使其在聊天窗口右侧显示您发送的消息，在左侧显示其他用户发送的消息。

主要变化：
- 在 'chat.php' 中：我通过全局 'currentUser' 变量向 JavaScript 公开了您登录的用户名。
- 在 'main.js' 中：我更新了 'addMessage' 函数以检查消息发件人是否与 'currentUser' 匹配。如果是这样，则 'current-user-message' CSS 类将添加到 message 元素中。
- 在 'styles.css' 中：我利用了现有的样式。'.messages' 容器使用带有 'align-items： flex-start' 的 flexbox（默认左对齐）。'.current-user-message' 类使用 'align-self： flex-end' 将这些特定消息向右移动，并应用不同的背景颜色。

此更改通过清楚地区分自己的消息和来自其他人的消息来增强聊天的可读性。