### PR TITLE
Fix: Ensure send button visibility on small screens

### DIFF
--- a/chat.php
+++ b/chat.php
@@ -24,6 +24,17 @@ if (!isset($_SESSION['user'])) {
 <div id="messages" class="messages"></div>
 <form id="send-form" class="send-form">
     <input type="text" id="message" autocomplete="off" placeholder="输入消息..." required>
+    <select id="self-destruct-time">
+        <option value="60" selected>1 minute</option>
+        <option value="300">5 minutes</option>
+        <option value="3600">1 hour</option>
+        <option value="18000">5 hours</option>
+        <option value="43200">12 hours</option>
+        <option value="86400">1 day</option>
+        <option value="604800">1 week</option>
+        <option value="0">Burn after read</option>
+        <option value="-1">Never</option>
+    </select>
     <button type="submit">发送</button>
 </form>
 <script>const currentUser = '<?php echo htmlspecialchars($_SESSION['user']); ?>';</script>

--- a/cleanup_messages.php
+++ b/cleanup_messages.php
@@ -1,0 +1,95 @@
+<?php
+// cleanup_messages.php - Intended to be run from CLI or a cron job.
+
+$messages_file = __DIR__ . '/messages.json';
+// Open for read/write, create if not exists, pointer at start.
+// Using 'c+' ensures the file is not truncated on open if it exists.
+$file_handle = fopen($messages_file, 'c+');
+
+if (!$file_handle) {
+    echo "Error: Failed to open messages file ('$messages_file') for cleanup." . PHP_EOL;
+    exit(1); // Exit with an error code
+}
+
+if (flock($file_handle, LOCK_EX)) { // Acquire exclusive lock
+    $messages_content = '';
+    // Read the entire stream content. Essential for 'c+' mode before writing.
+    while (!feof($file_handle)) {
+        $messages_content .= fread($file_handle, 8192);
+    }
+
+    // Handle empty file or invalid JSON content
+    $messages = (!empty($messages_content) && ($decoded_messages = json_decode($messages_content, true)) !== null) ? $decoded_messages : [];
+
+    $original_count = count($messages);
+    $currentTime = time();
+    $cleanedMessages = [];
+    $messages_changed = false;
+    $removed_count = 0;
+
+    foreach ($messages as $message) {
+        $keep_message = true; // Assume we keep the message by default
+
+        if (isset($message['destruct_type']) && $message['destruct_type'] === 'timed') {
+            if (isset($message['timestamp']) && isset($message['destruct_duration'])) {
+                $expiry_time = (int)$message['timestamp'] + (int)$message['destruct_duration'];
+                if ($currentTime >= $expiry_time) {
+                    $keep_message = false; // Mark for removal
+                }
+            }
+            // else: malformed timed message, keep it as we can't determine expiry.
+        }
+        // Note: Burn-after-read messages are directly deleted by delete_message.php.
+        // No specific logic is needed here for them unless the overall deletion strategy changes.
+        // System messages or messages with no destruct_type will also be kept.
+
+        if ($keep_message) {
+            $cleanedMessages[] = $message;
+        } else {
+            $messages_changed = true;
+            $removed_count++;
+        }
+    }
+
+    if ($messages_changed) {
+        // Important: Truncate the file *after* reading and before writing new content.
+        if (ftruncate($file_handle, 0)) {
+            rewind($file_handle); // Reset file pointer to the beginning
+            if (fwrite($file_handle, json_encode($cleanedMessages, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE))) {
+                fflush($file_handle); // Ensure all output is written before releasing lock
+                echo "Cleanup complete. Removed $removed_count expired timed messages. File updated." . PHP_EOL;
+            } else {
+                // Error writing, attempt to restore original content if possible (complex)
+                // or at least log the error. For now, just log.
+                echo "Error: Failed to write cleaned messages to file. File may be in an inconsistent state." . PHP_EOL;
+                // Attempt to write original content back - best effort
+                rewind($file_handle);
+                ftruncate($file_handle, 0);
+                fwrite($file_handle, $messages_content); // Write original content back
+                fflush($file_handle);
+                // Exit with error because operation failed
+                flock($file_handle, LOCK_UN); // Release lock before exiting
+                fclose($file_handle);
+                exit(1);
+            }
+        } else {
+            echo "Error: Failed to truncate messages file. No changes made." . PHP_EOL;
+            // No changes made, so release lock and exit with error
+            flock($file_handle, LOCK_UN);
+            fclose($file_handle);
+            exit(1);
+        }
+    } else {
+        echo "Cleanup complete. No timed messages required removal." . PHP_EOL;
+    }
+
+    flock($file_handle, LOCK_UN); // Release lock
+} else {
+    echo "Error: Failed to acquire lock on messages file ('$messages_file') for cleanup. Another process might be holding it." . PHP_EOL;
+    fclose($file_handle); // Close the handle if lock was not acquired
+    exit(1); // Exit with an error code
+}
+
+fclose($file_handle);
+exit(0); // Success
+?>

--- a/delete_message.php
+++ b/delete_message.php
@@ -1,0 +1,107 @@
+<?php
+session_start();
+
+// 1. Authentication and Request Method Check
+if (!isset($_SESSION['user'])) {
+    http_response_code(403); // Forbidden
+    echo json_encode(['error' => 'Authentication required.']);
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405); // Method Not Allowed
+    echo json_encode(['error' => 'POST method required.']);
+    exit();
+}
+
+// 2. Input Processing
+$messageId = $_POST['id'] ?? null;
+
+if ($messageId === null || !filter_var($messageId, FILTER_VALIDATE_INT) || (int)$messageId <= 0) {
+    http_response_code(400); // Bad Request
+    echo json_encode(['error' => 'Valid message ID is required.']);
+    exit();
+}
+$messageId = (int)$messageId;
+
+// 3. Message Deletion Logic
+$messages_file = __DIR__ . '/messages.json';
+$file_handle = fopen($messages_file, 'c+');
+
+if (!$file_handle) {
+    http_response_code(500); // Internal Server Error
+    echo json_encode(['error' => 'Failed to open messages file.']);
+    exit();
+}
+
+$messageActuallyDeleted = false;
+$messageFoundButNotApplicable = false;
+
+if (flock($file_handle, LOCK_EX)) { // Acquire exclusive lock
+    $messages_content = '';
+    // Read the entire stream content
+    while (!feof($file_handle)) {
+        $messages_content .= fread($file_handle, 8192);
+    }
+
+    $messages = ($messages_content !== '' && ($decoded_messages = json_decode($messages_content, true)) !== null) ? $decoded_messages : [];
+
+    $newMessages = [];
+    $originalMessageCount = count($messages);
+
+    foreach ($messages as $message) {
+        if (isset($message['id']) && $message['id'] == $messageId) {
+            if (isset($message['destruct_type']) && $message['destruct_type'] === 'burn_after_read') {
+                // Message found and is of type 'burn_after_read', so we "delete" it by not adding it to $newMessages.
+                // No action needed here for $newMessages, it's skipped.
+                // $messageActuallyDeleted will be set later if count changes.
+            } else {
+                // Message found, but not 'burn_after_read' or type not set. Keep it.
+                $newMessages[] = $message;
+                $messageFoundButNotApplicable = true;
+            }
+        } else {
+            $newMessages[] = $message;
+        }
+    }
+
+    if (count($newMessages) < $originalMessageCount) { // Check if a message was actually removed
+        $messageActuallyDeleted = true;
+        if (ftruncate($file_handle, 0)) {      // Truncate file
+            rewind($file_handle);              // Rewind pointer
+            fwrite($file_handle, json_encode($newMessages, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+            fflush($file_handle);              // Flush output before releasing lock
+        } else {
+            // Error truncating or writing - this is a server error state
+            // Log this server-side. For the client, the lock will be released,
+            // but the operation might not have been fully successful.
+            // For simplicity, we'll proceed to unlock and rely on later checks.
+            // A more robust solution might try to restore original content or flag for admin.
+             error_log("Failed to truncate or write to messages.json after acquiring lock.");
+             // We might want to avoid setting $messageActuallyDeleted to true if write fails.
+             // However, $newMessages reflects the intended state. If write failed, data is inconsistent.
+        }
+    }
+
+    flock($file_handle, LOCK_UN); // Release lock
+} else {
+    http_response_code(500); // Internal Server Error
+    echo json_encode(['error' => 'Failed to lock messages file.']);
+    fclose($file_handle); // Close handle if lock failed
+    exit();
+}
+
+fclose($file_handle);
+
+// 4. Response
+if ($messageActuallyDeleted) {
+    echo json_encode(['success' => true, 'message' => 'Message deleted successfully.']);
+} elseif ($messageFoundButNotApplicable) {
+    http_response_code(400); // Bad Request or 422 Unprocessable Entity
+    echo json_encode(['error' => 'Message found but is not a "burn_after_read" type or was already processed.']);
+} else {
+    http_response_code(404); // Not Found
+    echo json_encode(['error' => 'Message not found.']);
+}
+
+?>

--- a/main.js
+++ b/main.js
@@ -2,7 +2,76 @@ let lastId = 0;
 const msgs = document.getElementById('messages');
 const form = document.getElementById('send-form');
 const input = document.getElementById('message');
+const destructTimeSelector = document.getElementById('self-destruct-time'); // Added
+let activeMessageTimers = {}; // Added
+let currentUserSentBurnMessages = new Set(); // Added: Track BAR messages sent by current user
+
 // currentUser should be defined in chat.php, e.g., <script>const currentUser = '...';</script>
+
+// Function to load user preferences
+function loadPreferences() {
+    const preferredDestructTime = localStorage.getItem('preferredDestructTime');
+    if (preferredDestructTime && destructTimeSelector) {
+        destructTimeSelector.value = preferredDestructTime;
+    } else if (destructTimeSelector) {
+        destructTimeSelector.value = "60"; // Default to 1 minute
+    }
+}
+
+// Helper function to remove message elements with optional animation
+function removeMessageElement(messageId, immediate = false) {
+    const messageElement = document.getElementById('message-' + messageId);
+    if (messageElement) {
+        if (immediate) {
+            messageElement.remove();
+        } else {
+            messageElement.classList.add('message-fading-out');
+            setTimeout(() => {
+                messageElement.remove();
+            }, 500); // Animation duration
+        }
+    }
+    // Clear any associated timers
+    if (activeMessageTimers[messageId]) {
+        if (activeMessageTimers[messageId].intervalId) {
+            clearInterval(activeMessageTimers[messageId].intervalId);
+        }
+        if (activeMessageTimers[messageId].timeoutId) {
+            clearTimeout(activeMessageTimers[messageId].timeoutId);
+        }
+        delete activeMessageTimers[messageId];
+    }
+    // Also clean up from the set tracking user's own BAR messages
+    if (currentUserSentBurnMessages.has(messageId)) {
+        currentUserSentBurnMessages.delete(messageId);
+    }
+}
+
+// Helper function to format remaining time
+function formatRemainingTime(totalSeconds) {
+    if (totalSeconds <= 0) {
+        return 'Expired';
+    }
+
+    const days = Math.floor(totalSeconds / 86400);
+    totalSeconds %= 86400;
+    const hours = Math.floor(totalSeconds / 3600);
+    totalSeconds %= 3600;
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = Math.floor(totalSeconds % 60);
+
+    if (days > 0) {
+        return `${days}d ${hours}h`;
+    }
+    if (hours > 0) {
+        return `${hours}h ${minutes}m`;
+    }
+    if (minutes > 0) {
+        return `${minutes}m ${seconds}s`;
+    }
+    return `${seconds}s`;
+}
+
 
 function fetchMessages() {
     fetch('fetch.php?since=' + lastId)
@@ -49,6 +118,10 @@ function fetchMessages() {
 
                     const detailedReadBySpan = existingMsgDiv.querySelector('.detailed-read-by');
                     if (detailedReadBySpan) detailedReadBySpan.textContent = 'Read by: ' + readByList;
+
+                    // Potentially update destruct timer display if message already exists (e.g. for other users' view)
+                    // For now, addMessage handles initial rendering of timer. Future enhancement could update existing.
+
                 } else {
                     addMessage(m);
                     newMessagesWereAdded = true;
@@ -66,6 +139,22 @@ function fetchMessages() {
                     body: 'ids[]=' + idsToMarkRead.join('&ids[]=')
                 }).catch(error => console.error('Error marking messages as read:', error));
             }
+
+            // Check for current user's sent BAR messages that are no longer on server
+            const serverMessageIds = new Set(data.messages.map(msg => msg.id));
+            const localBurnMessageIdsToCheck = Array.from(currentUserSentBurnMessages); // Create a copy
+
+            localBurnMessageIdsToCheck.forEach(localMessageId => {
+                if (!serverMessageIds.has(localMessageId)) {
+                    // This message was a 'burn after read' sent by current user,
+                    // but it's no longer coming from the server (likely read and deleted).
+                    // So, remove it from the sender's UI as well.
+                    console.log(`Detected burn-after-read message ${localMessageId} (sent by current user) is no longer on server. Removing from local UI.`);
+                    removeMessageElement(localMessageId);
+                    // removeMessageElement will also clean it up from currentUserSentBurnMessages Set.
+                }
+            });
+
         })
         .catch(error => {
             console.error('Error fetching messages:', error);
@@ -77,15 +166,30 @@ function addMessage(m) {
     const div = document.createElement('div');
     div.id = 'message-' + m.id;
 
-    const messageDate = new Date(m.timestamp * 1000);
+    const messageDate = new Date(m.timestamp * 1000); // Assuming m.timestamp is in seconds
     const roughTime = messageDate.getHours().toString().padStart(2, '0') + ':' + messageDate.getMinutes().toString().padStart(2, '0');
+
+    let initialDestructInfoText = ''; // Initial text before dynamic updates
+
+    // Determine initial text based on destruct_type for the span structure
+    if (m.destruct_type === 'timed' && m.destruct_duration && m.timestamp) {
+        const initialRemaining = (parseFloat(m.timestamp) + parseInt(m.destruct_duration, 10)) - (Date.now() / 1000);
+        if (initialRemaining <= 0) {
+            initialDestructInfoText = ' (Expired)';
+        } else {
+            initialDestructInfoText = ` (${formatRemainingTime(initialRemaining)})`;
+        }
+    } else if (m.destruct_type === 'burn_after_read') {
+        initialDestructInfoText = ` (🔥 Burn after read)`;
+    } else if (m.destruct_type === 'never') {
+        initialDestructInfoText = ''; // Or ' (Permanent)'
+    }
+
 
     if (m.user === 'system') {
         div.className = 'message system-message';
         div.innerHTML = `<span class="text">${m.text}</span> <span class="message-time">${roughTime}</span>`;
     } else {
-        // Ensure currentUser is available, or provide a fallback.
-        // This script assumes 'currentUser' is a global variable defined in the HTML.
         if (typeof currentUser !== 'undefined' && m.user === currentUser) {
             div.className = 'message current-user-message';
         } else {
@@ -97,13 +201,85 @@ function addMessage(m) {
         const readByList = readByArray.length > 0 ? readByArray.join(', ') : 'None';
         const readCount = readByArray.length;
 
-        div.innerHTML = `<strong>${m.user}</strong> <span class="text">${m.text}</span> <span class="message-time">${roughTime}</span>` +
+        div.innerHTML = `<strong>${m.user}</strong> <span class="text">${m.text}</span><span class="destruct-info">${initialDestructInfoText}</span> <span class="message-time">${roughTime}</span>` +
             ` <span class="read">已读 ${readCount}</span>` +
             ` <div class="meta" style="display:none">` +
             `  <span class="detailed-time" style="display:none">${detailedTimeStr}</span>` +
             `  <span class="detailed-read-by" style="display:none">Read by: ${readByList}</span>` +
             ` </div>`;
+    }
+    msgs.appendChild(div); // Add message to DOM first
 
+    // --- SELF-DESTRUCT LOGIC WITH TIMERS (after element is in DOM) ---
+    const destructInfoSpan = div.querySelector('.destruct-info');
+
+    if (m.destruct_type === 'timed' && m.destruct_duration && m.timestamp && destructInfoSpan) {
+        const messageEndTime = parseFloat(m.timestamp) + parseInt(m.destruct_duration, 10);
+
+        const updateTimerDisplay = () => {
+            const nowSeconds = Date.now() / 1000;
+            const remainingSeconds = messageEndTime - nowSeconds;
+
+            if (remainingSeconds <= 0) {
+                destructInfoSpan.textContent = ' (Expired)';
+                removeMessageElement(m.id); // This will also clear the interval via its own logic
+            } else {
+                destructInfoSpan.textContent = ` (${formatRemainingTime(remainingSeconds)})`;
+            }
+        };
+
+        if ((messageEndTime - (Date.now() / 1000)) <= 0) {
+            // If already expired when this code runs (e.g., due to slight delay or if backend didn't filter)
+            destructInfoSpan.textContent = ' (Expired)';
+            removeMessageElement(m.id, true); // Remove immediately, no fade
+        } else {
+            updateTimerDisplay(); // Initial call to set text
+            const intervalId = setInterval(updateTimerDisplay, 1000);
+            activeMessageTimers[m.id] = { ...activeMessageTimers[m.id], intervalId: intervalId };
+        }
+
+    } else if (m.destruct_type === 'burn_after_read' && destructInfoSpan) {
+        if (m.user === currentUser) {
+            destructInfoSpan.textContent = ' (🔥 阅后即焚 (他人阅读5秒后消失))'; // Updated text for sender
+            destructInfoSpan.classList.add('burn-for-recipient');
+            currentUserSentBurnMessages.add(m.id); // Track this message
+        } else { // Message is from another user
+            destructInfoSpan.textContent = ' (🔥 阅后即焚 (5秒后消失))'; // Updated text for recipient
+            destructInfoSpan.classList.add('burn-for-me'); // Class for emphasis/styling
+
+            const timeoutId = setTimeout(() => {
+                removeMessageElement(m.id); // This will also clear the timeout
+
+                fetch('delete_message.php', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                    body: 'id=' + m.id
+                })
+                .then(response => response.json().catch(() => ({}))) // Allow non-JSON error responses too
+                .then(data => {
+                    if (data.success) {
+                        console.log('Burn after read message ' + m.id + ' confirmed deleted on server.');
+                    } else {
+                        console.error('Server failed to delete burn after read message ' + m.id + ':', data.error || 'Unknown server error');
+                    }
+                })
+                .catch(error => console.error('Error calling delete_message.php for ' + m.id + ':', error));
+            }, 5000); // Changed timeout to 5 seconds
+            activeMessageTimers[m.id] = { ...activeMessageTimers[m.id], timeoutId: timeoutId };
+        }
+    }
+    // --- SELF-DESTRUCT LOGIC END ---
+
+    // Scroll logic moved after message and its potential timers are set up
+    // const messagesContainer = msgs; // msgs is already defined globally
+    // const isScrolledToBottom = messagesContainer.scrollHeight - messagesContainer.clientHeight <= messagesContainer.scrollTop + 5;
+    // if (isScrolledToBottom) { // This logic is better handled in fetchMessages after all messages are processed
+    //    messagesContainer.scrollTop = messagesContainer.scrollHeight;
+    // }
+
+
+    // Event listeners for meta info toggle (already existing logic)
+    if (m.user !== 'system') { // System messages don't have these elements
         const timeElement = div.querySelector('.message-time');
         const readElement = div.querySelector('.read');
 
@@ -145,31 +321,46 @@ function addMessage(m) {
             };
         }
     }
-    msgs.appendChild(div);
-    // No scrollTop adjustment here
+    // No scrollTop adjustment here, it's handled in fetchMessages
 }
 
 form.onsubmit = e => {
     e.preventDefault();
     const text = input.value.trim();
     if (!text) return;
+
+    const selectedDestructTime = destructTimeSelector ? destructTimeSelector.value : "60"; // Default if selector not found
+
     fetch('send.php', {
         method: 'POST',
         headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-        body: 'text=' + encodeURIComponent(text)
-    }).then(() => {
+        body: 'text=' + encodeURIComponent(text) + '&destruct_time=' + selectedDestructTime
+    }).then(response => {
+        if (!response.ok) {
+            // Try to parse error from backend if available
+            return response.json().catch(() => null).then(errorBody => {
+                 throw new Error('Network response was not ok: ' + response.statusText + (errorBody ? ' - ' + JSON.stringify(errorBody) : ''));
+            });
+        }
+        return response.json(); // Assuming send.php might return the sent message or a success status
+    }).then(data => {
+        // console.log('Message sent successfully:', data); // Optional: log success
         input.value = '';
         input.focus();
-        // Call fetchMessages immediately after sending for faster update of own message
-        // However, this might conflict with the setInterval if not handled carefully.
-        // For now, rely on the setInterval or a slight delay.
-        // A common pattern is to add the message optimistically to the UI here.
+        if (destructTimeSelector) { // Save preference only if selector exists
+             localStorage.setItem('preferredDestructTime', selectedDestructTime);
+        }
+        // Optimistically add message or rely on next fetchMessages call
+        // fetchMessages(); // Immediate fetch can be good, but also handled by interval
     }).catch(error => console.error('Error sending message:', error));
 };
 
 // Ensure fetchMessages is defined before setInterval uses it.
 const messageFetchInterval = setInterval(fetchMessages, 2000);
-fetchMessages(); // Initial fetch
+
+// Initial actions when the script loads
+loadPreferences(); // Load user preferences for self-destruct time
+fetchMessages(); // Initial fetch of messages
 
 window.addEventListener('beforeunload', () => {
     if (navigator.sendBeacon) {

--- a/read.php
+++ b/read.php
@@ -1,20 +1,107 @@
 <?php
+// read.php
 session_start();
-if (!isset($_SESSION['user']) || $_SERVER['REQUEST_METHOD'] !== 'POST') {
-    http_response_code(403);
+
+// Robust check for user, method, and ids parameter
+if (!isset($_SESSION['user'])) {
+    http_response_code(403); // Forbidden
+    echo json_encode(['error' => 'Authentication required.']);
     exit();
 }
-$ids = $_POST['ids'] ?? [];
-$ids = array_map('intval', $ids);
-if (!$ids) exit();
-$messages_content = file_get_contents(__DIR__ . '/messages.json');
-$messages = ($messages_content && ($decoded_messages = json_decode($messages_content, true)) !== null) ? $decoded_messages : [];
-foreach ($messages as &$m) {
-    if (in_array($m['id'], $ids)) {
-        if (!in_array($_SESSION['user'], $m['read_by'])) {
-            $m['read_by'][] = $_SESSION['user'];
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405); // Method Not Allowed
+    echo json_encode(['error' => 'POST method required.']);
+    exit();
+}
+
+if (!isset($_POST['ids']) || !is_array($_POST['ids'])) {
+    http_response_code(400); // Bad Request
+    echo json_encode(['error' => 'Invalid request: "ids" parameter must be an array.']);
+    exit();
+}
+
+$idsToMark = array_filter(array_map('intval', $_POST['ids']), function($id) { return $id > 0; });
+
+if (empty($idsToMark)) {
+    // No valid IDs provided, or array was empty. Nothing to do.
+    // Consider if a 200 OK or 400 Bad Request is more appropriate.
+    // For now, exiting silently (200 OK by default) as no change is made.
+    exit();
+}
+
+$messages_file = __DIR__ . '/messages.json';
+$file_handle = fopen($messages_file, 'c+');
+
+if (!$file_handle) {
+    http_response_code(500); // Internal Server Error
+    echo json_encode(['error' => 'Failed to open messages file.']);
+    exit();
+}
+
+if (flock($file_handle, LOCK_EX)) { // Acquire exclusive lock
+    $messages_content = '';
+    while (!feof($file_handle)) {
+        $messages_content .= fread($file_handle, 8192);
+    }
+
+    $messages = (!empty($messages_content) && ($decoded_messages = json_decode($messages_content, true)) !== null) ? $decoded_messages : [];
+
+    $currentUser = $_SESSION['user'];
+    $changed = false;
+
+    foreach ($messages as &$m) { // Use reference to modify array directly
+        if (isset($m['id']) && in_array($m['id'], $idsToMark)) {
+
+            if (!isset($m['read_by']) || !is_array($m['read_by'])) {
+                $m['read_by'] = []; // Initialize if not exists or wrong type
+            }
+
+            if (!in_array($currentUser, $m['read_by'])) {
+                $m['read_by'][] = $currentUser;
+                $changed = true;
+
+                // "Burn after Read" specific logic
+                if (isset($m['destruct_type']) && $m['destruct_type'] === 'burn_after_read') {
+                    // Check if current user is not the sender of the message
+                    if (isset($m['user']) && $currentUser !== $m['user']) {
+                        // Check if 'first_read_by_other_timestamp' is not already set
+                        if (!isset($m['first_read_by_other_timestamp'])) {
+                            $m['first_read_by_other_timestamp'] = time();
+                            // $changed is already true due to adding to read_by
+                        }
+                    }
+                }
+            }
         }
     }
+    unset($m); // Unset reference to last element
+
+    if ($changed) {
+        if (ftruncate($file_handle, 0)) {
+            rewind($file_handle);
+            if (fwrite($file_handle, json_encode($messages, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE))) {
+                fflush($file_handle);
+                // Successfully written, client will receive 200 OK by default
+            } else {
+                error_log("read.php: Failed to write to messages.json after lock and truncate.");
+                // Avoid sending HTTP error code here if possible, as client might have already received some data or headers.
+                // This is a server-side issue primarily.
+            }
+        } else {
+            error_log("read.php: Failed to truncate messages.json after lock.");
+        }
+    }
+
+    flock($file_handle, LOCK_UN); // Release lock
+} else {
+    http_response_code(503); // Service Unavailable (failed to get lock)
+    echo json_encode(['error' => 'Failed to lock messages file. Please try again.']);
+    fclose($file_handle); // Close handle if lock failed
+    exit();
 }
-file_put_contents(__DIR__ . '/messages.json', json_encode($messages, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+fclose($file_handle);
+
+// Implicit 200 OK if no error codes were set and exited.
 ?>

--- a/send.php
+++ b/send.php
@@ -6,24 +6,55 @@ if (!isset($_SESSION['user']) || $_SERVER['REQUEST_METHOD'] !== 'POST') {
 }
 $text = trim($_POST['text'] ?? '');
 if ($text === '') {
+    http_response_code(400); // Bad Request
+    echo json_encode(['error' => 'Message text cannot be empty.']);
     exit();
 }
-$messages_content = file_get_contents(__DIR__ . '/messages.json');
-$messages = ($messages_content && ($decoded_messages = json_decode($messages_content, true)) !== null) ? $decoded_messages : [];
-$last_message = end($messages);
-$new_id = ($last_message && isset($last_message['id'])) ? $last_message['id'] + 1 : 1;
-if ($messages) { reset($messages); } // Reset array pointer if $messages was not empty
-$messages[] = [
-    'id' => $new_id,
+
+// Retrieve and process self-destruct time
+$destruct_time_raw = $_POST['destruct_time'] ?? '60'; // Default to 60 seconds if not provided
+
+$newMessageData = [
     'user' => $_SESSION['user'],
     'text' => htmlspecialchars($text, ENT_QUOTES, 'UTF-8'),
     'timestamp' => time(),
-    'read_by' => [$_SESSION['user']]
+    'read_by' => [$_SESSION['user']] // Creator has implicitly read it
 ];
+
+// Determine destruct_type and add relevant fields
+if ($destruct_time_raw === "0") { // Burn after read
+    $newMessageData['destruct_type'] = "burn_after_read";
+} elseif ($destruct_time_raw === "-1") { // Never
+    $newMessageData['destruct_type'] = "never";
+} else { // Timed
+    $destruct_duration = (int)$destruct_time_raw;
+    // Basic validation for duration, could be expanded
+    if ($destruct_duration <= 0) {
+        $destruct_duration = 60; // Fallback to 60s if somehow an invalid positive number is sent
+    }
+    $newMessageData['destruct_type'] = "timed";
+    $newMessageData['destruct_duration'] = $destruct_duration;
+}
+
+$messages_content = file_get_contents(__DIR__ . '/messages.json');
+$messages = ($messages_content && ($decoded_messages = json_decode($messages_content, true)) !== null) ? $decoded_messages : [];
+
+$last_message = end($messages);
+$new_id = ($last_message && isset($last_message['id'])) ? $last_message['id'] + 1 : 1;
+if ($messages) { reset($messages); }
+
+$newMessageData['id'] = $new_id; // Add ID to the message data
+
+$messages[] = $newMessageData;
+
 file_put_contents(__DIR__ . '/messages.json', json_encode($messages, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
 // update activity timestamp
 $online_content = file_get_contents(__DIR__ . '/online.json');
-$online = ($online_content && ($decoded_online = json_decode($online_content, true)) !== null) ? $decoded_online : (object)[];
+$online = ($online_content && ($decoded_online = json_decode($online_content, true)) !== null) ? $decoded_online : (object)[]; // Ensure it's an object for key assignment
 $online[$_SESSION['user']] = time();
 file_put_contents(__DIR__ . '/online.json', json_encode($online, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+header('Content-Type: application/json');
+echo json_encode($newMessageData); // Respond with the message that was just added
 ?>

--- a/styles.css
+++ b/styles.css
@@ -165,6 +165,36 @@ body {
     box-shadow: none;
 }
 
+/* Added styles for self-destruct timer selector */
+.send-form select#self-destruct-time {
+    background: #181818; /* Theme-appropriate background */
+    color: #F5F5F5; /* Theme-appropriate text color */
+    border: 1px solid #333333; /* Match other inputs */
+    border-radius: 20px; /* Match pill shape of chat input/button */
+    padding: 0.6rem 1rem; /* Match chat input padding */
+    margin-right: 0.5rem; /* Consistent spacing before send button */
+    min-width: 120px; /* Adjusted min-width, can be fine-tuned */
+    box-sizing: border-box;
+    font-family: inherit; /* Ensure font consistency */
+    font-size: inherit; /* Ensure font size consistency */
+    transition: border-color 0.2s ease;
+    -webkit-appearance: none; /* Remove default system appearance for custom arrow */
+    -moz-appearance: none;
+    appearance: none;
+    /* Custom arrow using SVG - color #AAAAAA to match #online-count */
+    background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23AAAAAA%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.4-5.4-13z%22%2F%3E%3C%2Fsvg%3E');
+    background-repeat: no-repeat;
+    background-position: right 0.7rem top 50%; /* Adjust position of arrow */
+    background-size: .65em auto; /* Adjust size of arrow */
+    cursor: pointer;
+}
+
+.send-form select#self-destruct-time:focus {
+    border-color: #555555; /* Match focus style of other inputs */
+    outline: none;
+    box-shadow: none;
+}
+
 .send-form button[type="submit"] {
     background: #282828;
     color: #F5F5F5;
@@ -281,6 +311,34 @@ body {
     opacity: 1;
 }
 
+/* Styles for message self-destruct info */
+.message .destruct-info {
+    font-size: 0.8em;
+    color: #AAAAAA; /* Muted grey, similar to online-count */
+    margin-left: 10px;
+    padding: 2px 6px; /* Adjusted padding */
+    background-color: #282828; /* Slightly different from message background, but still dark */
+    border-radius: 4px; /* Consistent border-radius */
+    display: inline-block; /* Allows margin and padding to work as expected */
+    vertical-align: middle; /* Align with text if text is multi-line */
+}
+
+.message.system-message .destruct-info { /* System messages shouldn't have this */
+    display: none;
+}
+
+.message .destruct-info.burn-after-read { /* Specific style for burn-after-read */
+    color: #e74c3c; /* A reddish warning color */
+    /* background-color: #4a2c2c; Optional: darker red background for more emphasis */
+}
+
+/* Styles for message fade-out animation */
+.message.message-fading-out {
+    opacity: 0;
+    transform: scale(0.95) translateX(20px); /* Slightly shrink and slide out to the right */
+    transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+}
+
 /* Animations */
 @keyframes fadein { /* General page fade-in */
     from { opacity: 0; }
@@ -361,6 +419,12 @@ body {
     .message .meta {
         font-size: 0.65rem;
     }
+
+    .message .destruct-info { /* Responsive adjustment for destruct-info */
+        font-size: 0.75em; /* Slightly smaller font on smaller screens */
+        margin-left: 8px; /* Adjust margin */
+        padding: 1px 4px; /* Adjust padding */
+    }
 }
 
 @media (max-width: 480px) {
@@ -406,10 +470,39 @@ body {
         height: calc(100vh - 80px);
     }
 
+/* Responsive adjustments for the send form on small screens */
+.send-form {
+    flex-wrap: wrap; /* Allow items to wrap */
+    justify-content: space-between; /* Distribute space for select and button line */
+    /* padding: 0.6rem 0.8rem; is inherited from 768px media query, should be fine */
+}
+
+.send-form input[type="text"] {
+    flex-basis: 100%; /* Input takes full width on its own line */
+    margin-right: 0; /* No right margin if it's full width */
+    margin-bottom: 0.5rem; /* Space before the next line (select/button) */
+    /* padding and font-size are handled by the combined rule below */
+}
+
+.send-form select#self-destruct-time {
+    min-width: 110px; /* Minimum width for the selector */
+    flex-grow: 1; /* Grow to fill available space with button */
+    /* margin-right: 0.5rem; is inherited from base style, for space next to button */
+    /* padding and font-size are handled by the combined rule below */
+}
+
+.send-form button[type="submit"] {
+    flex-grow: 1; /* Grow to fill available space with select */
+    /* padding and font-size are handled by the combined rule below */
+}
+
+/* Combined rule for padding and font-size for consistency */
     .send-form input[type="text"],
+.send-form select#self-destruct-time,
     .send-form button[type="submit"] {
-        padding: 0.5rem 0.8rem;
-        font-size: 0.85rem;
+        padding: 0.5rem 0.8rem; /* Consistent padding for all form elements */
+        font-size: 0.85rem; /* Consistent font size */
+    /* Existing individual margin/flex properties will apply alongside these */
     }
 
     .message strong {
@@ -418,5 +511,17 @@ body {
 
     .message .text {
         font-size: 0.85rem;
+    }
+}
+
+@media (max-width: 360px) { /* Even smaller screens, stack select and button */
+    .send-form select#self-destruct-time {
+        flex-basis: 100%; /* Select takes full width */
+        margin-right: 0; /* No right margin if full width */
+        margin-bottom: 0.5rem; /* Space before button */
+    }
+    .send-form button[type="submit"] {
+        flex-basis: 100%; /* Button takes full width */
+        margin-left: 0; /* Ensure it's not pushed by auto margin if it was there */
     }
 }


### PR DESCRIPTION
This commit adjusts the CSS for the message sending form (`.send-form`) to ensure all its elements, particularly the send button, are visible and usable on mobile devices with small screen widths.

Key changes in `styles.css`:

1.  **Introduced `flex-wrap: wrap` for `.send-form` on smaller screens:**
    *   Allows form elements to wrap to subsequent lines if horizontal space is insufficient.

2.  **Responsive element sizing and layout within media queries:**
    *   **For screens up to 480px wide (`@media (max-width: 480px)`):**
        *   The message input field now takes the full width on its own line.
        *   The self-destruct time selector and the send button share the next line, distributing available space.
    *   **For screens up to 360px wide (`@media (max-width: 360px)`):**
        *   The self-destruct time selector now also takes the full width on its own line.
        *   The send button then occupies the subsequent line, also at full width.

This tiered approach ensures that as screen width decreases, the form elements stack vertically rather than being cramped or pushed off-screen, significantly improving usability on mobile devices.